### PR TITLE
feat: :sparkles: add network-based checkpoint retrieval and update re…

### DIFF
--- a/src/controllers/checkpoint.controller.ts
+++ b/src/controllers/checkpoint.controller.ts
@@ -46,6 +46,20 @@ export const getCheckpointsByBranchId = async (
   });
 };
 
+export const getCheckpointsByNetworkId = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { networkId } = req.params;
+  const checkpoints = await checkpointService.getByNetworkId(
+    parseInt(networkId)
+  );
+  return res.status(200).json({
+    message: "Checkpoints obtenidos correctamente",
+    data: checkpoints,
+  });
+};
+
 export const createCheckpoint = async (
   req: Request,
   res: Response

--- a/src/interfaces/dto/checkpoint.dto.ts
+++ b/src/interfaces/dto/checkpoint.dto.ts
@@ -1,7 +1,7 @@
 export interface CheckpointDto {
   name: string;
   branch_id: number;
-  nfc_uid: string;
+  network_id: number;
   created_at?: Date;
   deleted_at?: Date;
 }

--- a/src/interfaces/entity/network.entity.ts
+++ b/src/interfaces/entity/network.entity.ts
@@ -37,18 +37,4 @@ export class Network {
 
   @UpdateDateColumn({ type: "timestamptz" })
   updatedAt: Date;
-
-  @BeforeInsert()
-  async hashPassword() {
-    if (this.password) {
-      this.password = await bcrypt.hash(this.password, 10);
-    }
-  }
-
-  @BeforeUpdate()
-  async hashPasswordOnUpdate() {
-    if (this.password) {
-      this.password = await bcrypt.hash(this.password, 10);
-    }
-  }
 }

--- a/src/routes/checkpoint.route.ts
+++ b/src/routes/checkpoint.route.ts
@@ -3,6 +3,7 @@ import {
   getAllCheckpoints,
   getCheckpointById,
   getCheckpointsByBranchId,
+  getCheckpointsByNetworkId,
   createCheckpoint,
   updateCheckpoint,
   deleteCheckpoint,
@@ -43,7 +44,11 @@ const router = Router();
  */
 router.get("/", authenticateToken, getAllCheckpoints);
 
-router.post("/mark-checkpoint", MarkCheckpointPatrolValidator, markCheckpointPatrol);
+router.post(
+  "/mark-checkpoint",
+  MarkCheckpointPatrolValidator,
+  markCheckpointPatrol
+);
 /**
  * @swagger
  * /checkpoints/{id}:
@@ -114,6 +119,40 @@ router.get("/branch/:branchId", authenticateToken, getCheckpointsByBranchId);
 
 /**
  * @swagger
+ * /checkpoints/network/{networkId}:
+ *   get:
+ *     summary: Obtener checkpoints por red
+ *     tags: [Checkpoints]
+ *     description: Retorna todos los checkpoints de una red específica
+ *     parameters:
+ *       - in: path
+ *         name: networkId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID de la red
+ *     responses:
+ *       200:
+ *         description: Checkpoints obtenidos exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Checkpoints obtenidos correctamente"
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Checkpoint'
+ *       500:
+ *         description: Error interno del servidor
+ */
+router.get("/network/:networkId", authenticateToken, getCheckpointsByNetworkId);
+
+/**
+ * @swagger
  * /checkpoints:
  *   post:
  *     summary: Crear un nuevo checkpoint
@@ -128,6 +167,7 @@ router.get("/branch/:branchId", authenticateToken, getCheckpointsByBranchId);
  *             required:
  *               - name
  *               - branch_id
+ *               - network_id
  *             properties:
  *               name:
  *                 type: string
@@ -135,6 +175,9 @@ router.get("/branch/:branchId", authenticateToken, getCheckpointsByBranchId);
  *               branch_id:
  *                 type: integer
  *                 description: ID de la sucursal
+ *               network_id:
+ *                 type: integer
+ *                 description: ID de la red
  *     responses:
  *       201:
  *         description: Checkpoint creado exitosamente
@@ -188,6 +231,9 @@ router.post("/", authenticateToken, CheckpointValidator, createCheckpoint);
  *               branch_id:
  *                 type: integer
  *                 description: ID de la sucursal
+ *               network_id:
+ *                 type: integer
+ *                 description: ID de la red
  *     responses:
  *       200:
  *         description: Checkpoint actualizado exitosamente

--- a/src/services/checkpoint.service.ts
+++ b/src/services/checkpoint.service.ts
@@ -25,27 +25,35 @@ export class CheckpointService {
     const checkpoint = this.checkpointRepository.create({
       name: checkpointDto.name,
       branch: { id: checkpointDto.branch_id },
+      network: { id: checkpointDto.network_id },
     });
     return await this.checkpointRepository.save(checkpoint);
   }
 
   async getAll(): Promise<Checkpoint[]> {
     return await this.checkpointRepository.find({
-      relations: ["branch"],
+      relations: ["branch", "network"],
     });
   }
 
   async getById(id: number): Promise<Checkpoint | null> {
     return await this.checkpointRepository.findOne({
       where: { id },
-      relations: ["branch"],
+      relations: ["branch", "network"],
     });
   }
 
   async getByBranchId(branchId: number): Promise<Checkpoint[]> {
     return await this.checkpointRepository.find({
       where: { branch: { id: branchId } },
-      relations: ["branch"],
+      relations: ["branch", "network"],
+    });
+  }
+
+  async getByNetworkId(networkId: number): Promise<Checkpoint[]> {
+    return await this.checkpointRepository.find({
+      where: { network: { id: networkId } },
+      relations: ["branch", "network"],
     });
   }
 
@@ -62,6 +70,8 @@ export class CheckpointService {
     if (checkpointDto.name) updateData.name = checkpointDto.name;
     if (checkpointDto.branch_id)
       updateData.branch = { id: checkpointDto.branch_id };
+    if (checkpointDto.network_id)
+      updateData.network = { id: checkpointDto.network_id };
 
     await this.checkpointRepository.update(id, updateData);
     return await this.getById(id);

--- a/src/utils/seeds/checkpoint.seed.ts
+++ b/src/utils/seeds/checkpoint.seed.ts
@@ -1,10 +1,12 @@
 import { AppDataSource } from "@configs/data-source";
 import { Checkpoint } from "@entities/checkpoint.entity";
 import { Branch } from "@entities/branch.entity";
+import { Network } from "@entities/network.entity";
 
 export async function seedCheckpoints() {
   const checkpointRepository = AppDataSource.getRepository(Checkpoint);
   const branchRepository = AppDataSource.getRepository(Branch);
+  const networkRepository = AppDataSource.getRepository(Network);
 
   // Obtener branches existentes
   const branches = await branchRepository.find();
@@ -13,31 +15,62 @@ export async function seedCheckpoints() {
     return;
   }
 
+  // Crear o obtener redes para cada branch
+  const networks: Network[] = [];
+  for (const branch of branches) {
+    let network = await networkRepository.findOne({
+      where: { branch: { id: branch.id } },
+    });
+
+    if (!network) {
+      network = networkRepository.create({
+        ssid: `Red_${branch.name || branch.id}`,
+        password: "password123",
+        branch: { id: branch.id },
+      });
+      await networkRepository.save(network);
+      console.log(
+        `✅ Created network: ${network.ssid} for branch ${branch.id}`
+      );
+    } else {
+      console.log(
+        `⚠️  Network ${network.ssid} already exists for branch ${branch.id}`
+      );
+    }
+    networks.push(network);
+  }
+
   const checkpoints = [
     // Checkpoints para la primera branch
     {
       name: "Entrada Principal",
       branch: { id: branches[0].id },
+      network: { id: networks[0].id },
     },
     {
       name: "Recepción",
       branch: { id: branches[0].id },
+      network: { id: networks[0].id },
     },
     {
       name: "Estacionamiento",
       branch: { id: branches[0].id },
+      network: { id: networks[0].id },
     },
     {
       name: "Sala de Espera",
       branch: { id: branches[0].id },
+      network: { id: networks[0].id },
     },
     {
       name: "Pasillo Principal",
       branch: { id: branches[0].id },
+      network: { id: networks[0].id },
     },
     {
       name: "Salida de Emergencia",
       branch: { id: branches[0].id },
+      network: { id: networks[0].id },
     },
     // Checkpoints para la segunda branch (si existe)
     ...(branches.length > 1
@@ -45,26 +78,32 @@ export async function seedCheckpoints() {
           {
             name: "Entrada Secundaria",
             branch: { id: branches[1].id },
+            network: { id: networks[1].id },
           },
           {
             name: "Área de Oficinas",
             branch: { id: branches[1].id },
+            network: { id: networks[1].id },
           },
           {
             name: "Cocina",
             branch: { id: branches[1].id },
+            network: { id: networks[1].id },
           },
           {
             name: "Baños",
             branch: { id: branches[1].id },
+            network: { id: networks[1].id },
           },
           {
             name: "Sótano",
             branch: { id: branches[1].id },
+            network: { id: networks[1].id },
           },
           {
             name: "Terraza",
             branch: { id: branches[1].id },
+            network: { id: networks[1].id },
           },
         ]
       : []),
@@ -74,26 +113,32 @@ export async function seedCheckpoints() {
           {
             name: "Entrada Norte",
             branch: { id: branches[2].id },
+            network: { id: networks[2].id },
           },
           {
             name: "Área de Servicios",
             branch: { id: branches[2].id },
+            network: { id: networks[2].id },
           },
           {
             name: "Almacén",
             branch: { id: branches[2].id },
+            network: { id: networks[2].id },
           },
           {
             name: "Sala de Reuniones",
             branch: { id: branches[2].id },
+            network: { id: networks[2].id },
           },
           {
             name: "Área de Descanso",
             branch: { id: branches[2].id },
+            network: { id: networks[2].id },
           },
           {
             name: "Salida Trasera",
             branch: { id: branches[2].id },
+            network: { id: networks[2].id },
           },
         ]
       : []),
@@ -115,7 +160,7 @@ export async function seedCheckpoints() {
       const checkpoint = checkpointRepository.create(checkpointData);
       await checkpointRepository.save(checkpoint);
       console.log(
-        `✅ Created checkpoint: ${checkpointData.name} for branch ${checkpointData.branch.id}`
+        `✅ Created checkpoint: ${checkpointData.name} for branch ${checkpointData.branch.id} with network ${checkpointData.network.id}`
       );
     }
   }

--- a/src/utils/validators/checkpoint.validator.ts
+++ b/src/utils/validators/checkpoint.validator.ts
@@ -1,6 +1,7 @@
 import { body } from "express-validator";
 import { AppDataSource } from "@configs/data-source";
 import { Branch } from "@entities/branch.entity";
+import { Network } from "@entities/network.entity";
 
 export const CheckpointValidator = [
   body("name")
@@ -23,6 +24,20 @@ export const CheckpointValidator = [
       }
       return true;
     }),
+  body("network_id")
+    .exists()
+    .withMessage("El ID de la red es requerido")
+    .bail()
+    .isInt()
+    .withMessage("El ID de la red debe ser un número entero")
+    .custom(async (value) => {
+      const networkRepository = AppDataSource.getRepository(Network);
+      const network = await networkRepository.findOne({ where: { id: value } });
+      if (!network) {
+        throw new Error("Red no encontrada");
+      }
+      return true;
+    }),
 ];
 
 export const CheckpointUpdateValidator = [
@@ -40,6 +55,22 @@ export const CheckpointUpdateValidator = [
         const branch = await branchRepository.findOne({ where: { id: value } });
         if (!branch) {
           throw new Error("Sucursal no encontrada");
+        }
+      }
+      return true;
+    }),
+  body("network_id")
+    .optional()
+    .isInt()
+    .withMessage("El ID de la red debe ser un número entero")
+    .custom(async (value) => {
+      if (value) {
+        const networkRepository = AppDataSource.getRepository(Network);
+        const network = await networkRepository.findOne({
+          where: { id: value },
+        });
+        if (!network) {
+          throw new Error("Red no encontrada");
         }
       }
       return true;


### PR DESCRIPTION
…lated entities

- Introduced a new endpoint to fetch checkpoints by network ID in the checkpoint controller and routes.
- Updated CheckpointDto to replace nfc_uid with network_id for better clarity.
- Enhanced CheckpointService to support fetching checkpoints by network ID.
- Modified the checkpoint seeding process to associate checkpoints with their respective networks.
- Added validation for network_id in checkpoint creation and update processes.